### PR TITLE
Config fixes

### DIFF
--- a/sw/drivers/astropix/asic.py
+++ b/sw/drivers/astropix/asic.py
@@ -372,7 +372,7 @@ class Asic():
 
             # SIN (bit 3 in register)
             sinValue = (1 if bit == True else 0) << 2
-            self.rfg.addWrite(register = targetRegister, value = sinValue)
+            self.rfg.addWrite(register = targetRegister, value = sinValue, repeat = ckdiv) #ensure SIN has higher delay than CLK1 to avoid setup violation / incorrect sampling
 
             # CK1
             self.rfg.addWrite(register = targetRegister, value = sinValue | 0x1 , repeat = ckdiv)

--- a/sw/drivers/boards/board_driver.py
+++ b/sw/drivers/boards/board_driver.py
@@ -202,21 +202,27 @@ class BoardDriver():
         #    regval = regval | ( disable_autoread << 2 )
         await getattr(self.rfg, f"write_layer_{layer}_cfg_ctrl")(regval,flush)
     
-    async def setLayerConfig(self,layer:int, reset : bool, autoread : bool   , hold:bool , flush = False):
-        """Modified the layer confi with provided bools
+    async def setLayerConfig(self,layer:int, reset : bool, autoread : bool, hold:bool , flush = False):
+        """Modified the layer config with provided bools
 
         Args:
-            disable_autoread (int): By default 1, disables the automatic layer readout upon interruptn=0 condition
-            modify (bool): Reads the Control register first and only change the required bits
+            autoread (bool): Assert/deassert reset in ctrl register
+            reset (bool): Assert/deassert reset in ctrl register
+            hold (bool): Assert/deassert hold in ctrl register
             flush (bool): Write the register right away
         
         """
         regval =  await getattr(self.rfg, f"read_layer_{layer}_cfg_ctrl")()
-      
+
         if reset is True:
             regval |= (1<<1)
         else:
             regval &= ~(1<<1)
+
+        if hold is True:
+            regval |= 1 
+        else: 
+            regval &= 0XFE
 
         if autoread is False:
             regval |= (1<<2)


### PR DESCRIPTION
[AS] Backend updates relating to chip configuration.

1.  Update of setLayerConfig to include 'hold'
2.  Update delay of clocks to avoid setup violations, recommended by Nicolas