### PR TITLE
SPI/Housekeeping: corrected cpol/cpha in spi master, and ADC config i…

### DIFF
--- a/fw/common/rtl/spi/spi_axis_if_v2.sv
+++ b/fw/common/rtl/spi/spi_axis_if_v2.sv
@@ -103,9 +103,9 @@ module spi_axis_if_v2 #( parameter QSPI = 0) (
 
     // This is a bit confusing, to output on posedge the logic runs during the negedge state
     wire        mosi_output = !stall_module && ( (cpha == 0 && cpol ==0  && spi_clock_state == A) ||
-                                (cpha == 0 && cpol == 1  && spi_clock_state == B) ||
+                                (cpha == 0 && cpol == 1  && spi_clock_state == A) ||
                                (cpha == 1 && cpol ==0  && spi_clock_state == B) ||
-                               (cpha == 1 && cpol ==1  && spi_clock_state == A) );
+                               (cpha == 1 && cpol ==1  && spi_clock_state == B) );
     wire        miso_sample = !stall_module && spi_clock_state != IDLE && !mosi_output;
 
     wire        mosi_can_take_next = (mosi_bit == 'd7 && spi_clock_state == B) ||spi_clock_state == IDLE ;

--- a/sw/drivers/astep/housekeeping.py
+++ b/sw/drivers/astep/housekeeping.py
@@ -89,11 +89,11 @@ class Housekeeping():
         # Reason is that if all bits change at once, the clock polarity will change after chip select is low, creating an edge that will be wrongly interpreted
 
         # Change CPOL/CPHA
-        # For ADC: CPOL=1, CPHA=0 , msb first- Output on falling edge, capture on rising edge
+        # For ADC: CPOL=1, CPHA=1 , msb first- Output on falling edge, capture on rising edge
         # For DAC: CPOL=0, CPHA=1  - Output on rising edge, capture on Falling edge
         regval = 0
         if adc is True:
-            regval |= (1 << 2) | (0 << 3) | (1 << 4)
+            regval |= (1 << 2) | (1 << 3) | (1 << 4)
         else:
             regval |= (0 << 2) | (1 << 3)
 


### PR DESCRIPTION
…n housekeeping

SPI master had two cpol/cpha config wrongly interpreted